### PR TITLE
Fixing subtle problem found in manual build testing: if Boost and cap…

### DIFF
--- a/src/ipc/util/detail/util.cpp
+++ b/src/ipc/util/detail/util.cpp
@@ -152,13 +152,3 @@ void remove_persistent_shm_pool(flow::log::Logger* logger_ptr, const Shared_name
 } // remove_persistent_shm_pool()
 
 } // namespace ipc::util
-
-namespace capnp
-{
-
-std::ostream& operator<<(std::ostream& os, const Text::Reader& val)
-{
-  return os << val.cStr();
-}
-
-} // namespace capnp

--- a/src/ipc/util/detail/util_fwd.hpp
+++ b/src/ipc/util/detail/util_fwd.hpp
@@ -21,7 +21,6 @@
 #include "ipc/util/util_fwd.hpp"
 #include "ipc/util/shared_name_fwd.hpp"
 #include <flow/common.hpp>
-#include <capnp/blob.h>
 
 namespace ipc::util
 {
@@ -229,32 +228,3 @@ class Timer_event_emitter;
 std::ostream& operator<<(std::ostream& os, const Timer_event_emitter& val);
 
 } // namespace ipc::util::sync_io
-
-/**
- * Small group of miscellaneous utilities to ease work with capnp (Cap'n Proto), joining its `capnp` namespace.
- * As of this writing circumstances have to very particular and rare indeed for something to actually be added
- * by us to this namespace.  As I write this, it contains only `oparator<<(std::ostream&, capnp::Text::Reader&)`.
- */
-namespace capnp
-{
-
-/**
- * Prints string representation of the given `capnp::Text::Reader` to the given `ostream`.
- *
- * ### Rationale for existence ###
- * Well, capnp does not provide it, even though it provides a conversion operator to `string` and such; and
- * it's nice to be able to print these (particularly when logging with `FLOW_LOG_*()`).
- * For whatever reason the auto-conversion operator does not "kick in" when placed in a
- * an `ostream<<` context; so such printing does not compile (nor does `lexical_cast<string>`).
- *
- * It won't be forced on anyone that doesn't include the present detail/ header.
- *
- * @param os
- *        Stream to which to write.
- * @param val
- *        Object to serialize.
- * @return `os`.
- */
-std::ostream& operator<<(std::ostream& os, const Text::Reader& val);
-
-} // namespace capnp


### PR DESCRIPTION
…np are not being installed into the same root include-path, ipc_core will fail to build.  Root reason: a little thingie really belonged in ipc_transport_structured, not ipc_core!  Now moving from the latter repo to the former.