### PR TITLE
UBSAN, ASAN, MSAN work and any errors - (Eddy-test-code) UBSAN found …

### DIFF
--- a/src/ipc/test/test_logger.hpp
+++ b/src/ipc/test/test_logger.hpp
@@ -28,7 +28,7 @@ namespace ipc::test
  * Logger used for testing purposes.
  */
 class Test_logger :
-  public flow::log::Simple_ostream_logger
+  public flow::log::Logger
 {
 public:
   /**
@@ -37,11 +37,13 @@ public:
    * @param min_severity Lowest severity that will pass through logging filter.
    */
   Test_logger(const flow::log::Sev& min_severity = Test_config::get_singleton().m_sev) :
-    flow::log::Simple_ostream_logger(&m_config),
-    m_config(min_severity)
+    m_config(min_severity),
+    m_logger(&m_config)
   {
+    // Yes, it is formally (and practically) fine to do this after the Logger took the m_config ptr already.
     m_config.init_component_to_union_idx_mapping<Log_component>(100, 100);
     m_config.init_component_names<Log_component>(ipc::S_IPC_LOG_COMPONENT_NAME_MAP, false, "test-");
+    // Now the logging may commence.
   }
   /**
    * Returns the logging configuration.
@@ -50,12 +52,32 @@ public:
    */
   flow::log::Config& get_config()
   {
-    return m_config;
+    return *m_logger.m_config;
+  }
+
+  /// Forwards to console Logger.
+  bool should_log(flow::log::Sev sev, const flow::log::Component& component) const override
+  {
+    return m_logger.should_log(sev, component);
+  }
+
+  /// Forwards to console Logger.
+  bool logs_asynchronously() const override
+  {
+    return m_logger.logs_asynchronously();
+  }
+
+  void do_log(flow::log::Msg_metadata* metadata, flow::util::String_view msg) override
+  {
+    m_logger.do_log(metadata, msg);
   }
 
 private:
   /// Logging configuration.
   flow::log::Config m_config;
+
+  /// The real logger.
+  flow::log::Simple_ostream_logger m_logger;
 }; // class Test_logger
 
 } // namespace ipc::test


### PR DESCRIPTION
…legit use of uninitialized memory; cannot give Simple_ostream_logger base ptr (or ref) to uninitialized Config like this, even though it is then initialized on the next line.  I changed Test_logger to composition which is functionally identical albeit a few more lines.