### PR TITLE
Boost v1.84 to 1.87 in Flow => slight breaking API changes in flow::error => fix/improve their use in this module. / Bug fix in Bipc_mq_handle wait-based APIs exception-throwing form.

### DIFF
--- a/src/ipc/transport/asio_local_stream_socket.cpp
+++ b/src/ipc/transport/asio_local_stream_socket.cpp
@@ -38,7 +38,6 @@ size_t nb_write_some_with_native_handle(flow::log::Logger* logger_ptr,
                                         Native_handle payload_hndl, const util::Blob_const& payload_blob,
                                         Error_code* err_code)
 {
-  namespace bind_ns = flow::util::bind_ns;
   using boost::system::system_category;
   using boost::array;
   namespace sys_err_codes = boost::system::errc;
@@ -52,8 +51,8 @@ size_t nb_write_some_with_native_handle(flow::log::Logger* logger_ptr,
   using ::MSG_NOSIGNAL;
   // using ::errno; // It's a macro apparently.
 
-  FLOW_ERROR_EXEC_FUNC_AND_THROW_ON_ERROR(size_t, nb_write_some_with_native_handle,
-                                          logger_ptr, peer_socket_ptr, payload_hndl, bind_ns::cref(payload_blob), _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(size_t, nb_write_some_with_native_handle,
+                                     logger_ptr, peer_socket_ptr, payload_hndl, payload_blob, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   /* To reader/maintainer: The below isn't that difficult, but if you need exact understanding and definitely if you
@@ -206,7 +205,6 @@ size_t nb_read_some_with_native_handle(flow::log::Logger* logger_ptr,
                                        Error_code* err_code,
                                        int message_flags)
 {
-  namespace bind_ns = flow::util::bind_ns;
   using boost::system::system_category;
   using boost::array;
   namespace sys_err_codes = boost::system::errc;
@@ -220,9 +218,9 @@ size_t nb_read_some_with_native_handle(flow::log::Logger* logger_ptr,
   using ::MSG_CTRUNC;
   // using ::errno; // It's a macro apparently.
 
-  FLOW_ERROR_EXEC_FUNC_AND_THROW_ON_ERROR(size_t, nb_read_some_with_native_handle,
-                                          logger_ptr, peer_socket_ptr, target_payload_hndl_ptr,
-                                          bind_ns::cref(target_payload_blob), _1, message_flags);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(size_t, nb_read_some_with_native_handle,
+                                     logger_ptr, peer_socket_ptr, target_payload_hndl_ptr,
+                                     target_payload_blob, _1, message_flags);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   /* To reader/maintainer: The below isn't that difficult, but if you need exact understanding and definitely if you

--- a/src/ipc/transport/bipc_mq_handle.cpp
+++ b/src/ipc/transport/bipc_mq_handle.cpp
@@ -636,7 +636,7 @@ bool Bipc_mq_handle::wait_impl([[maybe_unused]] util::Fine_duration timeout_from
   using Bipc_mq_mtx = bipc::interprocess_mutex;
   using Bipc_mq_lock = bipc::scoped_lock<Bipc_mq_mtx>;
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, wait_impl, timeout_from_now, _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, (wait_impl<WAIT_TYPE, SND_ELSE_RCV>), timeout_from_now, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   assert(m_mq

--- a/src/ipc/transport/bipc_mq_handle.cpp
+++ b/src/ipc/transport/bipc_mq_handle.cpp
@@ -155,7 +155,7 @@ bool Bipc_mq_handle::try_send(const util::Blob_const& blob, Error_code* err_code
 {
   using flow::util::buffers_dump_string;
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Bipc_mq_handle::try_send, flow::util::bind_ns::cref(blob), _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, try_send, blob, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   assert(m_mq && "As advertised: try_send() => undefined behavior if not successfully cted or was moved-from.");
@@ -268,8 +268,7 @@ bool Bipc_mq_handle::timed_send(const util::Blob_const& blob, util::Fine_duratio
   using boost::chrono::round;
   using boost::chrono::microseconds;
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Bipc_mq_handle::timed_send,
-                                     flow::util::bind_ns::cref(blob), timeout_from_now, _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, timed_send, blob, timeout_from_now, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   // Similar to a combo of (blocking) send() and (non-blocking) try_send() -- keeping comments light where redundant.
@@ -345,7 +344,7 @@ bool Bipc_mq_handle::try_receive(util::Blob_mutable* blob, Error_code* err_code)
   using flow::util::buffers_dump_string;
   using util::Blob_mutable;
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Bipc_mq_handle::try_receive, blob, _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, try_receive, blob, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   assert(m_mq && "As advertised: try_receive() => undefined behavior if not successfully cted or was moved-from.");
@@ -464,7 +463,7 @@ bool Bipc_mq_handle::timed_receive(util::Blob_mutable* blob, util::Fine_duration
   using boost::chrono::round;
   using boost::chrono::microseconds;
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Bipc_mq_handle::timed_receive, blob, timeout_from_now, _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, timed_receive, blob, timeout_from_now, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   // Similar to a combo of (blocking) receive() and (non-blocking) try_receive() -- keeping comments light.
@@ -637,7 +636,7 @@ bool Bipc_mq_handle::wait_impl([[maybe_unused]] util::Fine_duration timeout_from
   using Bipc_mq_mtx = bipc::interprocess_mutex;
   using Bipc_mq_lock = bipc::scoped_lock<Bipc_mq_mtx>;
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Bipc_mq_handle::timed_wait_receivable, timeout_from_now, _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, wait_impl, timeout_from_now, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   assert(m_mq

--- a/src/ipc/transport/detail/asio_local_stream_socket.cpp
+++ b/src/ipc/transport/detail/asio_local_stream_socket.cpp
@@ -28,12 +28,10 @@ namespace ipc::transport::asio_local_stream_socket
 Endpoint endpoint_at_shared_name(flow::log::Logger* logger_ptr,
                                  const Shared_name& absolute_name, Error_code* err_code)
 {
-  namespace bind_ns = flow::util::bind_ns;
   using boost::system::system_error;
   using std::string;
 
-  FLOW_ERROR_EXEC_FUNC_AND_THROW_ON_ERROR(Endpoint, endpoint_at_shared_name,
-                                          logger_ptr, bind_ns::cref(absolute_name), _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(Endpoint, endpoint_at_shared_name, logger_ptr, absolute_name, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   FLOW_LOG_SET_CONTEXT(logger_ptr, Log_component::S_TRANSPORT);

--- a/src/ipc/transport/detail/native_socket_stream_impl.cpp
+++ b/src/ipc/transport/detail/native_socket_stream_impl.cpp
@@ -183,8 +183,7 @@ bool Native_socket_stream::Impl::sync_connect(const Shared_name& absolute_name, 
 {
   using flow::util::ostream_op_string;
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Native_socket_stream::Impl::sync_connect,
-                                     flow::util::bind_ns::cref(absolute_name), _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, sync_connect, absolute_name, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   if (!m_sync_io.sync_connect(absolute_name, err_code))

--- a/src/ipc/transport/posix_mq_handle.cpp
+++ b/src/ipc/transport/posix_mq_handle.cpp
@@ -681,7 +681,7 @@ bool Posix_mq_handle::try_send(const util::Blob_const& blob, Error_code* err_cod
   using ::mq_send;
   // using ::EAGAIN; // A macro apparently.
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Posix_mq_handle::try_send, flow::util::bind_ns::cref(blob), _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, try_send, blob, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   assert((!m_mq.null())
@@ -807,8 +807,7 @@ bool Posix_mq_handle::timed_send(const util::Blob_const& blob, util::Fine_durati
   using ::mq_send;
   // using ::EAGAIN; // A macro apparently.
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Posix_mq_handle::timed_send,
-                                     flow::util::bind_ns::cref(blob), timeout_from_now, _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, timed_send, blob, timeout_from_now, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   // Similar to a combo of (blocking) send() and (non-blocking) try_send() -- keeping comments light where redundant.
@@ -885,7 +884,7 @@ bool Posix_mq_handle::try_receive(util::Blob_mutable* blob, Error_code* err_code
   using ::mq_receive;
   // using ::EAGAIN; // A macro apparently.
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Posix_mq_handle::try_receive, blob, _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, try_receive, blob, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   assert((!m_mq.null())
@@ -1007,8 +1006,7 @@ bool Posix_mq_handle::timed_receive(util::Blob_mutable* blob, util::Fine_duratio
   using ::mq_receive;
   // using ::EAGAIN; // A macro apparently.
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Posix_mq_handle::timed_receive,
-                                     blob, timeout_from_now, _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, timed_receive, blob, timeout_from_now, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   // Similar to a combo of (blocking) receive() and (non-blocking) try_receive() -- keeping comments light if redundant.
@@ -1189,7 +1187,7 @@ bool Posix_mq_handle::wait_impl(util::Fine_duration timeout_from_now_or_none, bo
   using ::epoll_wait;
   using Epoll_event = ::epoll_event;
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Posix_mq_handle::wait_impl, timeout_from_now_or_none, snd_else_rcv, _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, wait_impl, timeout_from_now_or_none, snd_else_rcv, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   assert((!m_mq.null())

--- a/src/ipc/transport/protocol_negotiator.cpp
+++ b/src/ipc/transport/protocol_negotiator.cpp
@@ -72,8 +72,7 @@ Protocol_negotiator::proto_ver_t Protocol_negotiator::negotiated_proto_ver() con
 
 bool Protocol_negotiator::compute_negotiated_proto_ver(proto_ver_t opposing_max_proto_ver, Error_code* err_code)
 {
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Protocol_negotiator::compute_negotiated_proto_ver,
-                                     opposing_max_proto_ver, _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, compute_negotiated_proto_ver, opposing_max_proto_ver, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   if (negotiated_proto_ver() != S_VER_UNKNOWN)

--- a/src/ipc/transport/sync_io/detail/blob_stream_mq_snd_impl.hpp
+++ b/src/ipc/transport/sync_io/detail/blob_stream_mq_snd_impl.hpp
@@ -882,8 +882,7 @@ bool Blob_stream_mq_sender_impl<Persistent_mq_handle>::send_blob(const util::Blo
   using boost::chrono::round;
   using boost::chrono::milliseconds;
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Blob_stream_mq_sender_impl<Persistent_mq_handle>::send_blob,
-                                     flow::util::bind_ns::cref(blob), _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, send_blob, blob, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   assert((blob.size() != 0) && "Do not send_blob() empty blobs.");

--- a/src/ipc/transport/sync_io/detail/native_socket_stream_impl.cpp
+++ b/src/ipc/transport/sync_io/detail/native_socket_stream_impl.cpp
@@ -188,8 +188,7 @@ bool Native_socket_stream::Impl::sync_connect(const Shared_name& absolute_name, 
   using util::sync_io::Asio_waitable_native_handle;
   using boost::promise;
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Native_socket_stream::Impl::sync_connect,
-                                     flow::util::bind_ns::cref(absolute_name), _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, sync_connect, absolute_name, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   /* Please see "Connect-ops impl design" in class doc header for background.  Long story short, though:
@@ -281,7 +280,6 @@ bool Native_socket_stream::Impl::sync_connect(const Shared_name& absolute_name, 
 void Native_socket_stream::Impl::async_connect(const Shared_name& absolute_name, Error_code* sync_err_code_ptr,
                                                flow::async::Task_asio_err&& on_done_func)
 {
-  namespace bind_ns = flow::util::bind_ns;
   using asio_local_stream_socket::Endpoint;
   using asio_local_stream_socket::Peer_socket;
   using asio_local_stream_socket::endpoint_at_shared_name;
@@ -475,8 +473,7 @@ util::Process_credentials
   using asio_local_stream_socket::Opt_peer_process_credentials;
   using util::Process_credentials;
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(Process_credentials, Native_socket_stream::Impl::remote_peer_process_credentials,
-                                     _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(Process_credentials, remote_peer_process_credentials, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   if (!state_peer("remote_peer_process_credentials()"))

--- a/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
+++ b/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
@@ -198,7 +198,7 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
     }; // const auto send_low_lvl_payload =
 
     /* Send-or-queue each payload of which we spoke above.  There's a very high chance all of this is done inline;
-     * but there's a small chance either there's either stuff queued already (we've delegated waiting for would-block
+     * but there's a small chance either there's stuff queued already (we've delegated waiting for would-block
      * to clear to user), or not but this can't fully complete (encountered would-block).  We don't care here per
      * se; I am just saying for context, to clarify what "send-or-queue" means. */
     send_low_lvl_payload(1, hndl_or_null, meta_length_blob); // It sets m_snd_pending_err_code.
@@ -208,7 +208,13 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
       send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.
     }
 
-    FLOW_LOG_WARNING("XXX: AFTER: send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.");
+    FLOW_LOG_WARNING("XXX2.0: AFTER: send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.");
+
+    FLOW_LOG_WARNING("XXX2.0: *err_code = [" << *err_code << "][" << err_code->message() >> "].");
+    FLOW_LOG_WARNING("XXX2.0: m_snd_pending_err_code = [" << m_snd_pending_err_code << "][" << m_snd_pending_err_code.message() >> "].");
+    flow::util::this_thread::sleep_for(boost::chrono::milliseconds(250));
+    FLOW_LOG_WARNING("XXX2.1: *err_code = [" << *err_code << "][" << err_code->message() >> "].");
+    FLOW_LOG_WARNING("XXX2.1: m_snd_pending_err_code = [" << m_snd_pending_err_code << "][" << m_snd_pending_err_code.message() >> "].");
 
     *err_code = m_snd_pending_err_code; // Emit the new error.
 

--- a/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
+++ b/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
@@ -202,12 +202,17 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
      * to clear to user), or not but this can't fully complete (encountered would-block).  We don't care here per
      * se; I am just saying for context, to clarify what "send-or-queue" means. */
     send_low_lvl_payload(1, hndl_or_null, meta_length_blob); // It sets m_snd_pending_err_code.
+    FLOW_LOG_WARNING("XXX: AFTER: send_low_lvl_payload(1, hndl_or_null, meta_length_blob); // It sets m_snd_pending_err_code.");
     if ((meta_length_raw != 0) && (!m_snd_pending_err_code))
     {
       send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.
     }
 
+    FLOW_LOG_WARNING("XXX: AFTER: send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.");
+
     *err_code = m_snd_pending_err_code; // Emit the new error.
+
+    FLOW_LOG_WARNING("XXX: AFTER: *err_code = m_snd_pending_err_code; // Emit the new error.");
 
     // Did either thing generate a new error?
     if (*err_code)
@@ -220,11 +225,14 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
     }
     else if (m_snd_auto_ping_period != Fine_duration::zero()) // && (!*err_code)
     {
+      FLOW_LOG_WARNING("XXX: IN: else if (m_snd_auto_ping_period != Fine_duration::zero()) // && (!*err_code)");
       /* Send requested, and there was no error; that represents non-idleness.  If auto_ping() has been called
        * (the feature is engaged), idleness shall occur at worst in m_snd_auto_ping_period; hence reschedule
        * snd_on_ev_auto_ping_now_timer_fired(). */
 
       const size_t n_canceled = m_snd_auto_ping_timer.expires_after(m_snd_auto_ping_period);
+
+      FLOW_LOG_WARNING("XXX: AFTER: [ " << n_canceled << "]: const size_t n_canceled = m_snd_auto_ping_timer.expires_after(m_snd_auto_ping_period);");
 
       FLOW_LOG_TRACE("Socket stream [" << *this << "]: Send request from user; hence rescheduled "
                      "auto-ping to occur in "
@@ -252,6 +260,8 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
   } /* else if (!m_snd_finished) && (meta_blob.size() OK) && (!m_snd_pending_err_code)
      *         (but m_snd_pending_err_code may have become truthy inside) */
 
+  FLOW_LOG_WARNING("XXX: BEFORE: if (*err_code)");
+
   if (*err_code)
   {
     // At the end try to categorize nature of error.
@@ -265,6 +275,8 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
                      "sending disabled by user? = "
                      "[" << (*err_code == error::Code::S_SENDS_FINISHED_CANNOT_SEND) << "].");
   }
+
+  FLOW_LOG_WARNING("XXX: AFTER: if (*err_code)");
 
   return true;
 } // Native_socket_stream::Impl::send_native_handle()

--- a/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
+++ b/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
@@ -202,23 +202,25 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
      * to clear to user), or not but this can't fully complete (encountered would-block).  We don't care here per
      * se; I am just saying for context, to clarify what "send-or-queue" means. */
     send_low_lvl_payload(1, hndl_or_null, meta_length_blob); // It sets m_snd_pending_err_code.
-    FLOW_LOG_WARNING("XXX: AFTER: send_low_lvl_payload(1, hndl_or_null, meta_length_blob); // It sets m_snd_pending_err_code.");
+    //FLOW_LOG_WARNING("XXX: AFTER: send_low_lvl_payload(1, hndl_or_null, meta_length_blob); // It sets m_snd_pending_err_code.");
     if ((meta_length_raw != 0) && (!m_snd_pending_err_code))
     {
       send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.
     }
 
+#if 0
     FLOW_LOG_WARNING("XXX2.0: AFTER: send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.");
 
     FLOW_LOG_WARNING("XXX2.0: *err_code = [" << *err_code << "][" << err_code->message() >> "].");
     FLOW_LOG_WARNING("XXX2.0: m_snd_pending_err_code = [" << m_snd_pending_err_code << "][" << m_snd_pending_err_code.message() >> "].");
-    flow::util::this_thread::sleep_for(boost::chrono::milliseconds(250));
+    //XXXflow::util::this_thread::sleep_for(boost::chrono::milliseconds(250));
     FLOW_LOG_WARNING("XXX2.1: *err_code = [" << *err_code << "][" << err_code->message() >> "].");
     FLOW_LOG_WARNING("XXX2.1: m_snd_pending_err_code = [" << m_snd_pending_err_code << "][" << m_snd_pending_err_code.message() >> "].");
+#endif
 
     *err_code = m_snd_pending_err_code; // Emit the new error.
 
-    FLOW_LOG_WARNING("XXX: AFTER: *err_code = m_snd_pending_err_code; // Emit the new error.");
+    //FLOW_LOG_WARNING("XXX: AFTER: *err_code = m_snd_pending_err_code; // Emit the new error.");
 
     // Did either thing generate a new error?
     if (*err_code)
@@ -231,14 +233,14 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
     }
     else if (m_snd_auto_ping_period != Fine_duration::zero()) // && (!*err_code)
     {
-      FLOW_LOG_WARNING("XXX: IN: else if (m_snd_auto_ping_period != Fine_duration::zero()) // && (!*err_code)");
+      //FLOW_LOG_WARNING("XXX: IN: else if (m_snd_auto_ping_period != Fine_duration::zero()) // && (!*err_code)");
       /* Send requested, and there was no error; that represents non-idleness.  If auto_ping() has been called
        * (the feature is engaged), idleness shall occur at worst in m_snd_auto_ping_period; hence reschedule
        * snd_on_ev_auto_ping_now_timer_fired(). */
 
       const size_t n_canceled = m_snd_auto_ping_timer.expires_after(m_snd_auto_ping_period);
 
-      FLOW_LOG_WARNING("XXX: AFTER: [ " << n_canceled << "]: const size_t n_canceled = m_snd_auto_ping_timer.expires_after(m_snd_auto_ping_period);");
+      //FLOW_LOG_WARNING("XXX: AFTER: [ " << n_canceled << "]: const size_t n_canceled = m_snd_auto_ping_timer.expires_after(m_snd_auto_ping_period);");
 
       FLOW_LOG_TRACE("Socket stream [" << *this << "]: Send request from user; hence rescheduled "
                      "auto-ping to occur in "
@@ -266,7 +268,7 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
   } /* else if (!m_snd_finished) && (meta_blob.size() OK) && (!m_snd_pending_err_code)
      *         (but m_snd_pending_err_code may have become truthy inside) */
 
-  FLOW_LOG_WARNING("XXX: BEFORE: if (*err_code)");
+  //FLOW_LOG_WARNING("XXX: BEFORE: if (*err_code)");
 
   if (*err_code)
   {
@@ -282,7 +284,7 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
                      "[" << (*err_code == error::Code::S_SENDS_FINISHED_CANNOT_SEND) << "].");
   }
 
-  FLOW_LOG_WARNING("XXX: AFTER: if (*err_code)");
+  //FLOW_LOG_WARNING("XXX: AFTER: if (*err_code)");
 
   return true;
 } // Native_socket_stream::Impl::send_native_handle()

--- a/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
+++ b/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
@@ -94,29 +94,15 @@ bool Native_socket_stream::Impl::send_blob(const util::Blob_const& blob, Error_c
 bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, const util::Blob_const& meta_blob,
                                                     Error_code* err_code)
 {
-  if (!err_code)
-  {
-    Error_code our_err_code;
-    const auto result = send_native_handle(hndl_or_null, meta_blob, &our_err_code);
-    if (our_err_code)
-    {
-      throw flow::error::Runtime_error(our_err_code, "send_native_handleXXX");
-    }
-    // else
-    return result;
-  }
-  // else if (err_code):
-
   using util::Fine_duration;
   using util::Blob_const;
   using flow::util::buffers_dump_string;
   using boost::chrono::round;
   using boost::chrono::milliseconds;
-#if 0
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Native_socket_stream::Impl::send_native_handle,
-                                     hndl_or_null, flow::util::bind_ns::cref(meta_blob), _1);
+
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR2("Native_socket_stream::Impl::send_native_handle()",
+                                     bool, send_native_handle, hndl_or_null, meta_blob, ARG_err_code);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
-#endif
 
   // We comment liberally, but tactically, inline; but please read the strategy in the class doc header's impl section.
 
@@ -223,6 +209,10 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
     }
 
 #if 0
+2025-01-16 06:56:31.736766293 +0000 [warn]: T7fe572183780: IPC-TRANSPORT: native_socket_stream_impl_snd.cpp:send_native_handle(211): XXX3.0: AFTER: send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.
+2025-01-16 06:56:31.861878422 +0000 [warn]: T7fe572183780: IPC-TRANSPORT: native_socket_stream_impl_snd.cpp:send_native_handle(213): XXX3.1: AFTER: flow::util::this_thread::sleep_for(boost::chrono::milliseconds(125));
+2025-01-16 06:56:31.861991853 +0000 [warn]: T7fe572183780: IPC-TRANSPORT: native_socket_stream_impl_snd.cpp:send_native_handle(214): XXX2.0: m_snd_pending_err_code = [system:0][Success].
+
     FLOW_LOG_WARNING("XXX3.0: AFTER: send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.");
     flow::util::this_thread::sleep_for(boost::chrono::milliseconds(125));
     FLOW_LOG_WARNING("XXX3.1: AFTER: flow::util::this_thread::sleep_for(boost::chrono::milliseconds(125));");

--- a/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
+++ b/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
@@ -208,13 +208,14 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
       send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.
     }
 
-    FLOW_LOG_WARNING("XXX2.0: AFTER: send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.");
-
-    FLOW_LOG_WARNING("XXX2.0: *err_code = [" << *err_code << "][" << err_code->message() << "].");
+    FLOW_LOG_WARNING("XXX3.0: AFTER: send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.");
+    flow::util::this_thread::sleep_for(boost::chrono::milliseconds(125));
+    FLOW_LOG_WARNING("XXX3.1: AFTER: flow::util::this_thread::sleep_for(boost::chrono::milliseconds(125));");
     FLOW_LOG_WARNING("XXX2.0: m_snd_pending_err_code = [" << m_snd_pending_err_code << "][" << m_snd_pending_err_code.message() << "].");
-    flow::util::this_thread::sleep_for(boost::chrono::milliseconds(250));
-    FLOW_LOG_WARNING("XXX2.1: *err_code = [" << *err_code << "][" << err_code->message() << "].");
+    FLOW_LOG_WARNING("XXX2.0: *err_code = [" << *err_code << "][" << err_code->message() << "].");
+    flow::util::this_thread::sleep_for(boost::chrono::milliseconds(125));
     FLOW_LOG_WARNING("XXX2.1: m_snd_pending_err_code = [" << m_snd_pending_err_code << "][" << m_snd_pending_err_code.message() << "].");
+    FLOW_LOG_WARNING("XXX2.1: *err_code = [" << *err_code << "][" << err_code->message() << "].");
 
     *err_code = m_snd_pending_err_code; // Emit the new error.
 

--- a/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
+++ b/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
@@ -100,8 +100,7 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
   using boost::chrono::round;
   using boost::chrono::milliseconds;
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR2("Native_socket_stream::Impl::send_native_handle()",
-                                     bool, send_native_handle, hndl_or_null, meta_blob, ARG_err_code);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, send_native_handle, hndl_or_null, meta_blob, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   // We comment liberally, but tactically, inline; but please read the strategy in the class doc header's impl section.
@@ -202,30 +201,12 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
      * to clear to user), or not but this can't fully complete (encountered would-block).  We don't care here per
      * se; I am just saying for context, to clarify what "send-or-queue" means. */
     send_low_lvl_payload(1, hndl_or_null, meta_length_blob); // It sets m_snd_pending_err_code.
-    //FLOW_LOG_WARNING("XXX: AFTER: send_low_lvl_payload(1, hndl_or_null, meta_length_blob); // It sets m_snd_pending_err_code.");
     if ((meta_length_raw != 0) && (!m_snd_pending_err_code))
     {
       send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.
     }
 
-#if 0
-2025-01-16 06:56:31.736766293 +0000 [warn]: T7fe572183780: IPC-TRANSPORT: native_socket_stream_impl_snd.cpp:send_native_handle(211): XXX3.0: AFTER: send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.
-2025-01-16 06:56:31.861878422 +0000 [warn]: T7fe572183780: IPC-TRANSPORT: native_socket_stream_impl_snd.cpp:send_native_handle(213): XXX3.1: AFTER: flow::util::this_thread::sleep_for(boost::chrono::milliseconds(125));
-2025-01-16 06:56:31.861991853 +0000 [warn]: T7fe572183780: IPC-TRANSPORT: native_socket_stream_impl_snd.cpp:send_native_handle(214): XXX2.0: m_snd_pending_err_code = [system:0][Success].
-
-    FLOW_LOG_WARNING("XXX3.0: AFTER: send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.");
-    flow::util::this_thread::sleep_for(boost::chrono::milliseconds(125));
-    FLOW_LOG_WARNING("XXX3.1: AFTER: flow::util::this_thread::sleep_for(boost::chrono::milliseconds(125));");
-    FLOW_LOG_WARNING("XXX2.0: m_snd_pending_err_code = [" << m_snd_pending_err_code << "][" << m_snd_pending_err_code.message() << "].");
-    FLOW_LOG_WARNING("XXX2.0: *err_code = [" << *err_code << "][" << err_code->message() << "].");
-    flow::util::this_thread::sleep_for(boost::chrono::milliseconds(125));
-    FLOW_LOG_WARNING("XXX2.1: m_snd_pending_err_code = [" << m_snd_pending_err_code << "][" << m_snd_pending_err_code.message() << "].");
-    FLOW_LOG_WARNING("XXX2.1: *err_code = [" << *err_code << "][" << err_code->message() << "].");
-#endif
-
     *err_code = m_snd_pending_err_code; // Emit the new error.
-
-    //FLOW_LOG_WARNING("XXX: AFTER: *err_code = m_snd_pending_err_code; // Emit the new error.");
 
     // Did either thing generate a new error?
     if (*err_code)
@@ -238,14 +219,11 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
     }
     else if (m_snd_auto_ping_period != Fine_duration::zero()) // && (!*err_code)
     {
-      //FLOW_LOG_WARNING("XXX: IN: else if (m_snd_auto_ping_period != Fine_duration::zero()) // && (!*err_code)");
       /* Send requested, and there was no error; that represents non-idleness.  If auto_ping() has been called
        * (the feature is engaged), idleness shall occur at worst in m_snd_auto_ping_period; hence reschedule
        * snd_on_ev_auto_ping_now_timer_fired(). */
 
       const size_t n_canceled = m_snd_auto_ping_timer.expires_after(m_snd_auto_ping_period);
-
-      //FLOW_LOG_WARNING("XXX: AFTER: [ " << n_canceled << "]: const size_t n_canceled = m_snd_auto_ping_timer.expires_after(m_snd_auto_ping_period);");
 
       FLOW_LOG_TRACE("Socket stream [" << *this << "]: Send request from user; hence rescheduled "
                      "auto-ping to occur in "
@@ -273,8 +251,6 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
   } /* else if (!m_snd_finished) && (meta_blob.size() OK) && (!m_snd_pending_err_code)
      *         (but m_snd_pending_err_code may have become truthy inside) */
 
-  //FLOW_LOG_WARNING("XXX: BEFORE: if (*err_code)");
-
   if (*err_code)
   {
     // At the end try to categorize nature of error.
@@ -288,8 +264,6 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
                      "sending disabled by user? = "
                      "[" << (*err_code == error::Code::S_SENDS_FINISHED_CANNOT_SEND) << "].");
   }
-
-  //FLOW_LOG_WARNING("XXX: AFTER: if (*err_code)");
 
   return true;
 } // Native_socket_stream::Impl::send_native_handle()

--- a/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
+++ b/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
@@ -100,7 +100,7 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
     const auto result = send_native_handle(hndl_or_null, meta_blob, &our_err_code);
     if (our_err_code)
     {
-      throw flow::util::Runtime_error(our_err_code, "send_native_handleXXX");
+      throw flow::error::Runtime_error(our_err_code, "send_native_handleXXX");
     }
     // else
     return result;

--- a/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
+++ b/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
@@ -210,10 +210,10 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
 
     FLOW_LOG_WARNING("XXX2.0: AFTER: send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.");
 
-    FLOW_LOG_WARNING("XXX2.0: *err_code = [" << *err_code << "][" << err_code->message() >> "].");
+    FLOW_LOG_WARNING("XXX2.0: *err_code = [" << *err_code << "][" << err_code->message() << "].");
     FLOW_LOG_WARNING("XXX2.0: m_snd_pending_err_code = [" << m_snd_pending_err_code << "][" << m_snd_pending_err_code.message() << "].");
     flow::util::this_thread::sleep_for(boost::chrono::milliseconds(250));
-    FLOW_LOG_WARNING("XXX2.1: *err_code = [" << *err_code << "][" << err_code->message() >> "].");
+    FLOW_LOG_WARNING("XXX2.1: *err_code = [" << *err_code << "][" << err_code->message() << "].");
     FLOW_LOG_WARNING("XXX2.1: m_snd_pending_err_code = [" << m_snd_pending_err_code << "][" << m_snd_pending_err_code.message() << "].");
 
     *err_code = m_snd_pending_err_code; // Emit the new error.

--- a/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
+++ b/src/ipc/transport/sync_io/detail/native_socket_stream_impl_snd.cpp
@@ -202,25 +202,23 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
      * to clear to user), or not but this can't fully complete (encountered would-block).  We don't care here per
      * se; I am just saying for context, to clarify what "send-or-queue" means. */
     send_low_lvl_payload(1, hndl_or_null, meta_length_blob); // It sets m_snd_pending_err_code.
-    //FLOW_LOG_WARNING("XXX: AFTER: send_low_lvl_payload(1, hndl_or_null, meta_length_blob); // It sets m_snd_pending_err_code.");
+    FLOW_LOG_WARNING("XXX: AFTER: send_low_lvl_payload(1, hndl_or_null, meta_length_blob); // It sets m_snd_pending_err_code.");
     if ((meta_length_raw != 0) && (!m_snd_pending_err_code))
     {
       send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.
     }
 
-#if 0
     FLOW_LOG_WARNING("XXX2.0: AFTER: send_low_lvl_payload(2, Native_handle(), meta_blob); // It sets m_snd_pending_err_code.");
 
     FLOW_LOG_WARNING("XXX2.0: *err_code = [" << *err_code << "][" << err_code->message() >> "].");
-    FLOW_LOG_WARNING("XXX2.0: m_snd_pending_err_code = [" << m_snd_pending_err_code << "][" << m_snd_pending_err_code.message() >> "].");
-    //XXXflow::util::this_thread::sleep_for(boost::chrono::milliseconds(250));
+    FLOW_LOG_WARNING("XXX2.0: m_snd_pending_err_code = [" << m_snd_pending_err_code << "][" << m_snd_pending_err_code.message() << "].");
+    flow::util::this_thread::sleep_for(boost::chrono::milliseconds(250));
     FLOW_LOG_WARNING("XXX2.1: *err_code = [" << *err_code << "][" << err_code->message() >> "].");
-    FLOW_LOG_WARNING("XXX2.1: m_snd_pending_err_code = [" << m_snd_pending_err_code << "][" << m_snd_pending_err_code.message() >> "].");
-#endif
+    FLOW_LOG_WARNING("XXX2.1: m_snd_pending_err_code = [" << m_snd_pending_err_code << "][" << m_snd_pending_err_code.message() << "].");
 
     *err_code = m_snd_pending_err_code; // Emit the new error.
 
-    //FLOW_LOG_WARNING("XXX: AFTER: *err_code = m_snd_pending_err_code; // Emit the new error.");
+    FLOW_LOG_WARNING("XXX: AFTER: *err_code = m_snd_pending_err_code; // Emit the new error.");
 
     // Did either thing generate a new error?
     if (*err_code)
@@ -233,14 +231,14 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
     }
     else if (m_snd_auto_ping_period != Fine_duration::zero()) // && (!*err_code)
     {
-      //FLOW_LOG_WARNING("XXX: IN: else if (m_snd_auto_ping_period != Fine_duration::zero()) // && (!*err_code)");
+      FLOW_LOG_WARNING("XXX: IN: else if (m_snd_auto_ping_period != Fine_duration::zero()) // && (!*err_code)");
       /* Send requested, and there was no error; that represents non-idleness.  If auto_ping() has been called
        * (the feature is engaged), idleness shall occur at worst in m_snd_auto_ping_period; hence reschedule
        * snd_on_ev_auto_ping_now_timer_fired(). */
 
       const size_t n_canceled = m_snd_auto_ping_timer.expires_after(m_snd_auto_ping_period);
 
-      //FLOW_LOG_WARNING("XXX: AFTER: [ " << n_canceled << "]: const size_t n_canceled = m_snd_auto_ping_timer.expires_after(m_snd_auto_ping_period);");
+      FLOW_LOG_WARNING("XXX: AFTER: [ " << n_canceled << "]: const size_t n_canceled = m_snd_auto_ping_timer.expires_after(m_snd_auto_ping_period);");
 
       FLOW_LOG_TRACE("Socket stream [" << *this << "]: Send request from user; hence rescheduled "
                      "auto-ping to occur in "
@@ -268,7 +266,7 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
   } /* else if (!m_snd_finished) && (meta_blob.size() OK) && (!m_snd_pending_err_code)
      *         (but m_snd_pending_err_code may have become truthy inside) */
 
-  //FLOW_LOG_WARNING("XXX: BEFORE: if (*err_code)");
+  FLOW_LOG_WARNING("XXX: BEFORE: if (*err_code)");
 
   if (*err_code)
   {
@@ -284,7 +282,7 @@ bool Native_socket_stream::Impl::send_native_handle(Native_handle hndl_or_null, 
                      "[" << (*err_code == error::Code::S_SENDS_FINISHED_CANNOT_SEND) << "].");
   }
 
-  //FLOW_LOG_WARNING("XXX: AFTER: if (*err_code)");
+  FLOW_LOG_WARNING("XXX: AFTER: if (*err_code)");
 
   return true;
 } // Native_socket_stream::Impl::send_native_handle()

--- a/src/ipc/util/process_credentials.cpp
+++ b/src/ipc/util/process_credentials.cpp
@@ -69,7 +69,7 @@ std::string Process_credentials::process_invoked_as(Error_code* err_code) const
   using std::string;
   // using ::errno; // It's a macro apparently.
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(std::string, Process_credentials::process_invoked_as, _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(string, process_invoked_as, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
 #ifndef FLOW_OS_LINUX


### PR DESCRIPTION
This is downstream of flow PR https://github.com/Flow-IPC/flow/pull/100. Quoting the only part of that relevant to these changes:

- APIs are unchanged except:
  - a mostly backward-compatible improvement in FLOW_ERROR_EXEC_AND_THROW_ON_ERROR();
    - (but remove any bind_ns::cref() wrappers for args - they're not necessary and won't build)
    
Basically, in English: All uses of bind() have been removed, eliminating any issue from Boost-1.87; and accordingly furthermore FLOW_ERROR_EXEC_AND_THROW_ON_ERROR() invocations have been simplified due to its new impl and improved API.

--

Additionally, the eagle-eyed reviewer will note there was a bug in the (slightly) changed code in Bipc_mq_handle::wait_impl() function template. If invoked in exception-throwing-on-error mode (err_code null), it would invoke the wrong method (an un-careful bug by me), thus breaking all wait-based APIs of Bipc_mq_handle except timed_receivable() (if and only if err_code=null mode is used).

This did not show up in testing because these methods are internally used in non-exception-throwing mode (err_code non-null) for perf reasons, and our extensive testing neglects to test the exception-throwing mode for that specific set of low-level (but still publicly available) APIs. (There is a ticket to formalize coverage, though informally I still claim quite decent coverage; but clearly this was a miss.)

Naturally the bug is fixed. I also scanned all nearby similar FLOW_ERROR_EXEC_AND_THROW_ON_ERROR() to ensure this mess-up wasn't elsewhere.