### PR TITLE
Internally to SHM-jemalloc use vaddr space less aggressively, avoiding eventual fatal error despite not-high SHM RAM use.

### DIFF
--- a/src/ipc/test/test_common_util.cpp
+++ b/src/ipc/test/test_common_util.cpp
@@ -64,12 +64,27 @@ static void collect_output(flow::util::String_ostream& ss,
                            bool output_buffer)
 {
   collect_output(ss.os(), func, os);
-  const string& output = ss.str();
   if (output_buffer)
   {
     // Output results
-    os << output;
+    os << ss.str();
+    os.flush();
   }
+}
+
+bool check_output(const string& output, const vector<string>& regex_matches)
+{
+  bool result = true;
+  for (auto const& iter : regex_matches)
+  {
+    std::regex cur_regex(iter);
+    if (!std::regex_search(output, cur_regex))
+    {
+      result = false;
+    }
+  }
+
+  return result;
 }
 
 bool check_output(const std::function<void()>& func,
@@ -89,19 +104,7 @@ bool check_output(const std::function<void()>& func,
   flow::util::String_ostream ss;
 
   collect_output(ss, func, os, output_buffer);
-  const string& output = ss.str();
-
-  bool result = true;
-  for (auto const& iter : regex_matches)
-  {
-    std::regex cur_regex(iter);
-    if (!std::regex_search(output, cur_regex))
-    {
-      result = false;
-    }
-  }
-
-  return result;
+  return check_output(ss.str(), regex_matches);
 }
 
 string collect_output(const std::function<void()>& func, ostream& os, bool output_buffer)

--- a/src/ipc/test/test_common_util.hpp
+++ b/src/ipc/test/test_common_util.hpp
@@ -34,6 +34,16 @@ namespace ipc::test
 std::string get_test_suite_name();
 
 /**
+ * Examines output for matches.
+ *
+ * @param output The output to match against.
+ * @param regex_matches The regular expression matches (gtest format) to check in the stream output.
+ * @param output_buffer Whether to output the contents of the buffer to the intended destination.
+ *
+ * @return Whether the output matched the expected regular expression.
+ */
+bool check_output(const std::string& output, const std::vector<std::string>& regex_matches);
+/**
  * Executes a function and examines stream output for a match.
  *
  * @param func The function to execute.
@@ -48,19 +58,29 @@ bool check_output(const std::function<void()>& func,
                   const std::string& regex_match,
                   bool output_buffer = true);
 /**
- * Executes a function and examines stream output for a match.
+ * Executes a function and examines stream output for matches.
  *
  * @param func The function to execute.
  * @param os The stream to check output on.
  * @param regex_matches The regular expression matches (gtest format) to check in the stream output.
  * @param output_buffer Whether to output the contents of the buffer to the intended destination.
  *
- * @return Whether the output matched the expected regular expression.
+ * @return Whether the output matched the expected regular expressions.
  */
 bool check_output(const std::function<void()>& func,
                   std::ostream& os,
                   const std::vector<std::string>& regex_matches,
                   bool output_buffer = true);
+/**
+ * Examines output for matches.
+ *
+ * @param output The output to match against.
+ * @param regex_matches The regular expression matches (gtest format) to check in the stream output.
+ * @param output_buffer Whether to output the contents of the buffer to the intended destination.
+ *
+ * @return Whether the output matched the expected regular expression.
+ */
+bool check_output(const std::string& output, const std::vector<std::string>& regex_matches);
 /**
  * Collects output during the execution of a function.
  *
@@ -70,7 +90,7 @@ bool check_output(const std::function<void()>& func,
  *
  * @return The collected output.
  */
-std::string collect_output(const std::function<void()>& func, std::ostream& os, bool output_buffer = true);
+std::string collect_output(const std::function<void()>& func, std::ostream& os = std::cout, bool output_buffer = true);
 /**
  * Returns the RSS memory used by the process.
  *


### PR DESCRIPTION
  Impl notes:
  - (by @echan-dev) Retain optionally requested shared memory pool removals. This is to avoid gaps and the eventual removal of the pool, which eventually may signal to jemalloc to increase the size by double in the next memory pool allocation.)

  Code review notes:

  @echan-dev made this change elsewhere. I have reviewed it. Therefore, forgoing code review in this PR. Additionally in this repo all changes are in test/.