### PR TITLE
Renaming various internal-use threads to be shorter and ideally with the more useful information up-front, in case the Linux cut-off limit truncates. / Using flow::async::reset_this_thread_pinning() at the start of various worker threads which should remain as independent and as responsive as possible.

### DIFF
--- a/src/ipc/transport/detail/blob_stream_mq_rcv_impl.hpp
+++ b/src/ipc/transport/detail/blob_stream_mq_rcv_impl.hpp
@@ -215,8 +215,12 @@ Blob_stream_mq_receiver_impl<Persistent_mq_handle>::Blob_stream_mq_receiver_impl
 template<typename Persistent_mq_handle>
 Blob_stream_mq_receiver_impl<Persistent_mq_handle>::Blob_stream_mq_receiver_impl
   (sync_io::Blob_stream_mq_receiver<Mq>&& sync_io_core_in_peer_state_moved) :
+
   flow::log::Log_context(sync_io_core_in_peer_state_moved.get_logger(), Log_component::S_TRANSPORT),
-  m_worker(sync_io_core_in_peer_state_moved.get_logger(), sync_io_core_in_peer_state_moved.nickname()),
+  m_worker(get_logger(),
+           /* (Linux) OS thread name will truncate .nickname() to 15-5=10 chars here; high chance that'll include
+            * something decently useful; probably not everything though; depends on nickname.  It's a decent attempt. */
+           flow::util::ostream_op_string("MQRc-", sync_io_core_in_peer_state_moved.nickname())),
   // Adopt the just-cted, idle sync_io:: core.
   m_sync_io(std::move(sync_io_core_in_peer_state_moved))
   // m_sync_io_adapter is null but is set-up shortly below.
@@ -224,8 +228,9 @@ Blob_stream_mq_receiver_impl<Persistent_mq_handle>::Blob_stream_mq_receiver_impl
   using util::sync_io::Asio_waitable_native_handle;
   using util::sync_io::Task_ptr;
   using flow::util::ostream_op_string;
+  using flow::async::reset_this_thread_pinning;
 
-  m_worker.start();
+  m_worker.start(reset_this_thread_pinning); // Don't inherit any strange core-affinity!  Worker must float free.
 
   // We're using a boost.asio event loop, so we need to base the async-waited-on handles on our Task_engine.
 #ifndef NDEBUG
@@ -237,7 +242,9 @@ Blob_stream_mq_receiver_impl<Persistent_mq_handle>::Blob_stream_mq_receiver_impl
 
   /* Have to do this after .replace_event_wait_handles() by the adapter's ctor's contract.
    * As of this writing that's the only reason m_sync_io_adapter is optional<>. */
-  m_sync_io_adapter.emplace(get_logger(), ostream_op_string("Blob_stream_mq_receiver [", *this, ']'),
+  m_sync_io_adapter.emplace(get_logger(),
+                            // Brief-ish for use in OS thread names or some such.
+                            ostream_op_string("MQRc-", nickname()),
                             &m_worker, &m_sync_io);
 } // Blob_stream_mq_receiver_impl::Blob_stream_mq_receiver_impl()
 
@@ -245,6 +252,7 @@ template<typename Persistent_mq_handle>
 Blob_stream_mq_receiver_impl<Persistent_mq_handle>::~Blob_stream_mq_receiver_impl()
 {
   using flow::async::Single_thread_task_loop;
+  using flow::async::reset_thread_pinning;
   using flow::util::ostream_op_string;
 
   // We are in thread U.  By contract in doc header, they must not call us from a completion handler (thread W).
@@ -269,9 +277,11 @@ Blob_stream_mq_receiver_impl<Persistent_mq_handle>::~Blob_stream_mq_receiver_imp
                 "from some other thread.  In this user thread we will await those handlers' completion and then "
                 "return.");
 
-  Single_thread_task_loop one_thread(get_logger(), ostream_op_string(nickname(), "-temp_deinit"));
+  Single_thread_task_loop one_thread(get_logger(), ostream_op_string("MQRcDeinit-", nickname()));
   one_thread.start([&]()
   {
+    reset_thread_pinning(get_logger()); // Don't inherit any strange core-affinity.  Float free.
+
     FLOW_LOG_INFO("Blob_stream_mq_receiver [" << *this << "]: "
                   "In transient finisher thread: Shall run all pending internal handlers (typically none).");
 

--- a/src/ipc/transport/native_socket_stream_acceptor.cpp
+++ b/src/ipc/transport/native_socket_stream_acceptor.cpp
@@ -42,7 +42,7 @@ Native_socket_stream_acceptor::Native_socket_stream_acceptor(flow::log::Logger* 
   m_worker(get_logger(), // Start the 1 thread.
            /* (Linux) OS thread name will truncate m_absolute_name to 15-5=10 chars here; high chance that'll include
             * something decently useful; probably not everything though.  It's a decent attempt. */
-           flow::util::ostream_op_string("NSSA-", m_absolute_name)),
+           flow::util::ostream_op_string("NSSA-", m_absolute_name.str())),
   m_next_peer_socket(*(m_worker.task_engine())) // Steady state: start it as empty, per doc header.
 {
   using asio_local_stream_socket::Acceptor;
@@ -153,7 +153,7 @@ Native_socket_stream_acceptor::~Native_socket_stream_acceptor()
 
   FLOW_LOG_INFO("Acceptor [" << *this << "]: Continuing shutdown.  Next we will run pending handlers from some "
                 "other thread.  In this user thread we will await those handlers' completion and then return.");
-  Single_thread_task_loop one_thread(get_logger(), ostream_op_string("NSSADeinit-", m_absolute_name));
+  Single_thread_task_loop one_thread(get_logger(), ostream_op_string("NSSADeinit-", m_absolute_name.str()));
 
   one_thread.start([&]()
   {

--- a/src/ipc/transport/native_socket_stream_acceptor.cpp
+++ b/src/ipc/transport/native_socket_stream_acceptor.cpp
@@ -39,7 +39,10 @@ Native_socket_stream_acceptor::Native_socket_stream_acceptor(flow::log::Logger* 
                                                              Error_code* err_code) :
   flow::log::Log_context(logger_ptr, Log_component::S_TRANSPORT),
   m_absolute_name(absolute_name_arg),
-  m_worker(get_logger(), flow::util::ostream_op_string(*this)), // Start the 1 thread.
+  m_worker(get_logger(), // Start the 1 thread.
+           /* (Linux) OS thread name will truncate m_absolute_name to 15-5=10 chars here; high chance that'll include
+            * something decently useful; probably not everything though.  It's a decent attempt. */
+           flow::util::ostream_op_string("NSSA-", m_absolute_name)),
   m_next_peer_socket(*(m_worker.task_engine())) // Steady state: start it as empty, per doc header.
 {
   using asio_local_stream_socket::Acceptor;
@@ -47,6 +50,7 @@ Native_socket_stream_acceptor::Native_socket_stream_acceptor(flow::log::Logger* 
   using asio_local_stream_socket::endpoint_at_shared_name;
   using util::String_view;
   using flow::error::Runtime_error;
+  using flow::async::reset_thread_pinning;
   using boost::system::system_error;
 
   /* For simplicity we'll just do all the work in thread W we're about to start.  Whether to do some initial stuff
@@ -58,6 +62,8 @@ Native_socket_stream_acceptor::Native_socket_stream_acceptor(flow::log::Logger* 
   FLOW_LOG_TRACE("Acceptor [" << *this << "]: Awaiting initial setup/listening in worker thread.");
   m_worker.start([&]() // Execute all this synchronously in the thread.
   {
+    reset_thread_pinning(get_logger()); // Don't inherit any strange core-affinity!  Worker must float free.
+
     auto const asio_engine = m_worker.task_engine();
 
     FLOW_LOG_INFO("Acceptor [" << *this << "]: Starting (am in worker thread).");
@@ -66,7 +72,7 @@ Native_socket_stream_acceptor::Native_socket_stream_acceptor(flow::log::Logger* 
     assert((local_endpoint == Endpoint()) == bool(sys_err_code));
     if (sys_err_code) // It logged.
     {
-      return; // Escape the post() callback, that is.
+      return; // Escape the start() callback, that is.
     }
     // else
 
@@ -85,7 +91,7 @@ Native_socket_stream_acceptor::Native_socket_stream_acceptor(flow::log::Logger* 
                        "be due to address/name clash; details logged below.");
       sys_err_code = exc.code();
       FLOW_ERROR_SYS_ERROR_LOG_WARNING();
-      return; // Escape the post() callback, that is.
+      return; // Escape the start() callback, that is.
     }
 
     FLOW_LOG_INFO("Acceptor [" << *this << "]: "
@@ -131,6 +137,8 @@ Native_socket_stream_acceptor::Native_socket_stream_acceptor(flow::log::Logger* 
 Native_socket_stream_acceptor::~Native_socket_stream_acceptor()
 {
   using flow::async::Single_thread_task_loop;
+  using flow::async::reset_thread_pinning;
+  using flow::util::ostream_op_string;
 
   // We are in thread U.  By contract in doc header, they must not call us from a completion handler (thread W).
 
@@ -145,9 +153,12 @@ Native_socket_stream_acceptor::~Native_socket_stream_acceptor()
 
   FLOW_LOG_INFO("Acceptor [" << *this << "]: Continuing shutdown.  Next we will run pending handlers from some "
                 "other thread.  In this user thread we will await those handlers' completion and then return.");
-  Single_thread_task_loop one_thread(get_logger(), "temp_deinit");
+  Single_thread_task_loop one_thread(get_logger(), ostream_op_string("NSSADeinit-", m_absolute_name));
+
   one_thread.start([&]()
   {
+    reset_thread_pinning(get_logger()); // Don't inherit any strange core-affinity.  Float free.
+
     FLOW_LOG_INFO("Acceptor [" << *this << "]: "
                   "In transient finisher thread: Shall run all pending internal handlers (typically none).");
 

--- a/src/ipc/util/sync_io/asio_waitable_native_hndl.cpp
+++ b/src/ipc/util/sync_io/asio_waitable_native_hndl.cpp
@@ -59,7 +59,7 @@ Asio_waitable_native_handle::~Asio_waitable_native_handle()
 
 Native_handle Asio_waitable_native_handle::native_handle()
 {
-  return Base::is_open()? Native_handle(Base::native_handle()) : Native_handle();
+  return Base::is_open() ? Native_handle(Base::native_handle()) : Native_handle();
 }
 
 void Asio_waitable_native_handle::assign(Native_handle hndl)


### PR DESCRIPTION
related to https://github.com/Flow-IPC/flow/issues/108, https://github.com/Flow-IPC/flow/issues/71, https://github.com/Flow-IPC/ipc/issues/85

## To code reviewer
Forgoing code review, because already reviewed elsewhere (@code-walkers).