### PR TITLE
For Channels opened via `ipc::session`, ensure the socket-stream-specific method `remote_peer_process_credentials()` returns values relevant to the opposing process despite the details of how such channels are internally established (namely via `socketpair()`). / Add `Native_socket_stream::remote_peer_process_credentials()` mutator that allows one to correct this value when creating socket-streams more manually (such as is done internally by `ipc::session`).

### DIFF
--- a/src/ipc/transport/channel.hpp
+++ b/src/ipc/transport/channel.hpp
@@ -1060,6 +1060,9 @@ public:
    * Identical to Native_socket_stream::remote_peer_process_credentials(): OS-reported process credential
    * (PID, etc.) info about the *other* connected peer's process.  See its doc header.
    *
+   * @warning Failing to know its exact semantics may lead to confusing results that wouldn't be immediately clear,
+   *          until the downstream bugs appear!
+   *
    * @param err_code
    *        See above.
    * @return See above.
@@ -1127,6 +1130,9 @@ public:
   /**
    * Identical to Native_socket_stream::remote_peer_process_credentials(): OS-reported process credential
    * (PID, etc.) info about the *other* connected peer's process.  See its doc header.
+   *
+   * @warning Failing to know its exact semantics may lead to confusing results that wouldn't be immediately clear,
+   *          until the downstream bugs appear!
    *
    * @param err_code
    *        See above.
@@ -1328,6 +1334,9 @@ public:
   /**
    * Identical to Native_socket_stream::remote_peer_process_credentials(): OS-reported process credential
    * (PID, etc.) info about the *other* connected peer's process.  See its doc header.
+   *
+   * @warning Failing to know its exact semantics may lead to confusing results that wouldn't be immediately clear,
+   *          until the downstream bugs appear!
    *
    * @param err_code
    *        See above.

--- a/src/ipc/transport/detail/native_socket_stream_impl.cpp
+++ b/src/ipc/transport/detail/native_socket_stream_impl.cpp
@@ -217,6 +217,11 @@ util::Process_credentials
   return m_sync_io.remote_peer_process_credentials(err_code);
 }
 
+bool Native_socket_stream::Impl::remote_peer_process_credentials(const util::Process_credentials& creds)
+{
+  return m_sync_io.remote_peer_process_credentials(creds);
+}
+
 const std::string& Native_socket_stream::Impl::nickname() const
 {
   return m_sync_io.nickname();

--- a/src/ipc/transport/detail/native_socket_stream_impl.hpp
+++ b/src/ipc/transport/detail/native_socket_stream_impl.hpp
@@ -259,6 +259,15 @@ public:
 
   /**
    * See Native_socket_stream counterpart.
+   *
+   * @param creds
+   *        See Native_socket_stream counterpart.
+   * @return See Native_socket_stream counterpart.
+   */
+  bool remote_peer_process_credentials(const util::Process_credentials& creds);
+
+  /**
+   * See Native_socket_stream counterpart.
    * @return See Native_socket_stream counterpart.
    */
   size_t send_meta_blob_max_size() const;

--- a/src/ipc/transport/native_socket_stream.cpp
+++ b/src/ipc/transport/native_socket_stream.cpp
@@ -96,6 +96,11 @@ util::Process_credentials Native_socket_stream::remote_peer_process_credentials(
   return impl()->remote_peer_process_credentials(err_code);
 }
 
+bool Native_socket_stream::remote_peer_process_credentials(const util::Process_credentials& creds)
+{
+  return impl()->remote_peer_process_credentials(creds);
+}
+
 size_t Native_socket_stream::send_meta_blob_max_size() const
 {
   return impl()->send_meta_blob_max_size();

--- a/src/ipc/transport/native_socket_stream.hpp
+++ b/src/ipc/transport/native_socket_stream.hpp
@@ -714,17 +714,52 @@ public:
   /**
    * OS-reported process credential (PID, etc.) info about the *other* connected peer's process, at the time
    * that the OS first established (via local-socket-connect or local-socket-connected-pair-generate call) that
-   * opposing peer socket.  The value returned, assuming a non-error-emitting execution, shall always be the same for a
-   * given `*this`.
+   * opposing peer socket -- unless overridden via mutator (please read here).
    *
-   * Informally: To avoid (though, formally, not guarantee) error::Code::S_LOW_LVL_TRANSPORT_HOSED, it is best
-   * to call this immediately upon entry of `*this` to PEER state and/or before
-   * invoking any other APIs.
+   * ### Exact semantics ###
+   * If one is not careful, it is possible to get in hard-to-realize trouble with this accessor.  Here are the
+   * exact semantics; then we'll briefly discuss their implications.
    *
-   * If invoked outside of PEER state returns `Process_credentials()` immediately
-   * and otherwise does nothing.
+   *   - If called in non-PEER state, returns `{}` but emits no error.
+   *   - If called in PEER state, but incoming/outgoing-direction processing earlier detected
+   *     that the underlying transport is hosed, returns `{}` (unless throws) and emits
+   *     error::Code::S_LOW_LVL_TRANSPORT_HOSED.
+   *     - As of this writing no other errors are possible.
+   *   - Otherwise (main case):
+   *     - If remote_peer_process_credentials() *mutator* has been called, returns copy of the value given to that
+   *       mutator last.  Otherwise:
+   *     - Returns the values accurate at the time that the connection was originally established.  To wit:
+   *       - If `*this` established connection via sync_connect() (or equivalent such as via native OS-connect):
+   *         returns the opposing process's info saved at the moment of successful OS-connect.
+   *       - If `*this` established connection via Native_socket_stream_acceptor::async_accept() (or equivalent such
+   *         as via native OS-accept):
+   *         returns the opposing process's info saved at the moment of successful OS-connect (background-accept op
+   *         subsequent to native OS-listen).
+   *       - If `*this` established connection via boost.asio `connect_pair()` (or equivalent such as via native OS
+   *         `socketpair()`): returns the info for the process that executed OS-socket-pair, at the time that
+   *         it was called.
    *
-   * @return See above; or `Peer_credentials()` if invoked outside of PEER state or in case of error.
+   * ### Rationale/implications ###
+   * In the *main case* path above: All of that is reasonable and as one would expect, with the exception of the very
+   * last bullet point, because typically (not always) one would then transmit one of the handles (FDs) returned by
+   * OS-socket-pair call to another process (over yet another Native_socket_stream) and then communicate over
+   * that channel.  In particular `ipc::session`-created `Channel`s internally operate that way.  In that case
+   * one might invoke remote_peer_process_credentials() and expect the PID/etc. of the opposing process; but that
+   * will be accurate only for the guy who received the handle/FD; whereas for the guy who sent it this method
+   * will return that guy's own PID... unhelpful, usually.
+   *
+   * The following are the key implications/corollaries of that.
+   *   - You should be aware of it, instead of assuming "opposing peer" means what you think it means.
+   *   - If you'd like to override this behavior, when it is inconvenient, use the mutator
+   *     remote_peer_process_credentials() (as shown above, those values will then be returned).  You would need
+   *     the correct values to pass to it, but these are usually available from the socket-stream used to
+   *     transmit the FD.  Namely one would perhaps call *that* guy's `.remote_peer_process_credentials()`.
+   *     - The `Channel`s returned by ipc::session already internally use this mechanism.  That is
+   *       Channel::remote_peer_process_credentials() will yield the actual opposing process's stuff, assuming
+   *       an ipc::session::Session or variant generated the Channel.  (If you create the `Channel` yourself, then
+   *       it is up to you to use the mutator to correct for this yourself.)
+   *
+   * @return See above; or `Peer_credentials{}` if invoked outside of PEER state or in case of error.
    *         The 2 eventualities can be distinguished by checking `*err_code` truthiness.  Better yet
    *         only call remote_peer_process_credentials() in PEER state, as it is otherwise conceptually meaningless.
    *
@@ -732,10 +767,25 @@ public:
    *        See `flow::Error_code` docs for error reporting semantics.  #Error_code generated:
    *        error::Code::S_LOW_LVL_TRANSPORT_HOSED (the incoming/outgoing-direction processing detected
    *        that the underlying transport is hosed; specific code was logged and can be obtained via
-   *        async_receive_native_handle() or similar),
-   *        system codes (albeit unlikely).
+   *        async_receive_native_handle() or similar).
    */
   util::Process_credentials remote_peer_process_credentials(Error_code* err_code = 0) const;
+
+  /**
+   * Overrides what same-named accessor shall return subsequently; useful when a socket-stream endpoint travels
+   * to another process relative to where the connection was first established.
+   *
+   * After calling this mutator, the same-named accessor shall return a value equal to `creds`, unless it yields
+   * `{}` (error case).
+   *
+   * @see doc header for remote_peer_process_credentials() accessor for important relevant information.
+   *
+   * @param creds
+   *        The value to save.
+   * @return `true` if called in PEER state (`creds` was saved);
+   *         `false` if called in another state (`creds` was not saved).
+   */
+  bool remote_peer_process_credentials(const util::Process_credentials& creds);
 
 private:
   // Types.

--- a/src/ipc/transport/sync_io/detail/native_socket_stream_impl.cpp
+++ b/src/ipc/transport/sync_io/detail/native_socket_stream_impl.cpp
@@ -171,6 +171,9 @@ Native_socket_stream::Impl::Impl(flow::log::Logger* logger_ptr, util::String_vie
 
   // Clear it; we've eaten it.
   native_peer_socket_moved = Native_handle();
+
+  // m_peer_socket is connected, so do this ASAP by its contract.
+  save_peer_process_creds();
 } // Native_socket_stream::Impl::Impl()
 
 Native_socket_stream::Impl::~Impl()
@@ -402,7 +405,13 @@ void Native_socket_stream::Impl::async_connect(const Shared_name& absolute_name,
                          "immediately but with error [" << sync_err_code << "] [" << sync_err_code.message() << "].  "
                          "Connect request failing.  Will emit error via sync-args.");
       }
-      // else { Success.  Reminder: this and fatal error are both much likelier than would-block. }
+      else
+      {
+        // Success.  Reminder: this and fatal error are both much likelier than would-block.
+
+        // m_peer_socket is connected, so do this ASAP by its contract.
+        save_peer_process_creds();
+      }
     } // if (!err_code) [m_peer_socket->non_blocking(true)] (but it may have become truthy inside)
     else // if (err_code) [m_peer_socket->non_blocking(true)]
     {
@@ -428,11 +437,22 @@ void Native_socket_stream::Impl::conn_on_ev_peer_socket_writable(flow::async::Ta
    * case where one can force a connectable-but-not-immediately situation -- hitting a backlog-full acceptor --
    * it'll still just succeed.  Anyway, if it weren't academic, then even if we falsely assume PEER state here,
    * when really m_peer_socket is hosed underneath, it'll just get exposed the moment we try to read or write.
-   * So just relax. */
+   * So just relax.
+   *
+   * Update: That was written before we added the save_peer_process_creds() call here.  It still holds, but the
+   * charade we are playing is furthered now; it's all academic, meaning in Linux at least the execution won't
+   * reach here; but if it did, what would it mean?  Well, hopefully save_peer_process_creds() would not fail.
+   * If it did fail, as currently written we consider this an impossibility and, like, std::abort().  So is that fine?
+   * That's almost a philosophical question... since execution cannot really reach here, so the hypothetical
+   * is essentially meaningless.  To summarize: this will vomit/abort() if the get-sock-opt fails here, which it
+   * won't, because none of this will execute.  @todo Be very careful here when extending the code to other OS! */
 
   FLOW_LOG_INFO("Socket stream [" << *this << "]: Writable-wait upon would-blocked connect attempt: done.  "
                 "Entering PEER state.  Will emit to completion handler.");
   m_state = State::S_PEER;
+
+  save_peer_process_creds();
+
   on_done_func(Error_code());
   FLOW_LOG_TRACE("Handler completed.");
 } // Native_socket_stream::Impl::conn_on_ev_peer_socket_writable()
@@ -470,33 +490,85 @@ bool Native_socket_stream::Impl::replace_event_wait_handles
   return true;
 } // Native_socket_stream::Impl::replace_event_wait_handles()
 
+void Native_socket_stream::Impl::save_peer_process_creds()
+{
+  using asio_local_stream_socket::Opt_peer_process_credentials;
+  using util::Process_credentials;
+
+  assert(m_peer_socket && "Internal bug: Contract violation?");
+
+  Error_code sys_err_code;
+  Opt_peer_process_credentials sock_opt; // Contains default-cted Process_credentials.
+  m_peer_socket->get_option(sock_opt, sys_err_code);
+
+  if (sys_err_code)
+  {
+    FLOW_LOG_FATAL("Socket stream [" << *this << "]: Get-sock-option call for Opt_peer_process_credentials failed.  "
+                   "For an ever-connected endpoint this should never happen.  If this endpoint originated inside "
+                   "Flow-IPC, there is a bug; please investigate call stack/etc.  If it originated from somewhat-exotic "
+                   "user code -- e.g., manual socketpair() -- then probably it is user error passing in invalid FD "
+                   "or some-such.  In that case perhaps @todo nicer error reporting.");
+    FLOW_ERROR_SYS_ERROR_LOG_FATAL();
+    assert(false
+             && "Get-sock-option call for Opt_peer_process_credentials failed.  "
+                "For an ever-connected endpoint this should never happen.  If this endpoint originated inside "
+                "Flow-IPC, there is a bug; please investigate call stack/etc.  If it originated from somewhat-exotic "
+                "user code -- e.g., manual socketpair() -- then probably it is user error passing in invalid FD "
+                "or some-such.  In that case perhaps @todo nicer error reporting.");
+    std::abort();
+  }
+  // else
+
+  m_peer_process_creds = sock_opt;
+
+  FLOW_LOG_INFO("Socket stream [" << *this << "]: At earliest opportunity saved opposing endpoint's process info "
+                "(can be overridden via mutator): [" << m_peer_process_creds << "].  "
+                "Here are our own creds: [" << Process_credentials::own_process_credentials() << "].");
+} // Native_socket_stream::Impl::save_peer_process_creds()
+
 util::Process_credentials
   Native_socket_stream::Impl::remote_peer_process_credentials(Error_code* err_code) const
 {
-  using asio_local_stream_socket::Opt_peer_process_credentials;
   using util::Process_credentials;
 
   FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(Process_credentials, remote_peer_process_credentials, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
-  if (!state_peer("remote_peer_process_credentials()"))
+  if (!state_peer("remote_peer_process_credentials(1)"))
   {
     err_code->clear(); // As promised.
-    return Process_credentials();
+    return {};
   }
   // else
 
   if (!m_peer_socket)
   {
     *err_code = error::Code::S_LOW_LVL_TRANSPORT_HOSED;
-    return Process_credentials();
+    return {};
   }
   // else
 
-  Opt_peer_process_credentials sock_opt; // Contains default-cted Process_credentials.
-  m_peer_socket->get_option(sock_opt, *err_code);
+  return m_peer_process_creds;
+} // Native_socket_stream::Impl::remote_peer_process_credentials()
 
-  return sock_opt;
+bool Native_socket_stream::Impl::remote_peer_process_credentials(const util::Process_credentials& creds)
+{
+  using util::Process_credentials;
+
+  if (!state_peer("remote_peer_process_credentials(2)"))
+  {
+    return false;
+  }
+  // else
+
+  FLOW_LOG_INFO("Socket stream [" << *this << "]: Overriding saved opposing-endpoint process info "
+                "via mutator: [" << creds << "].  "
+                "Previously saved values: [" << m_peer_process_creds << "].  "
+                "Here are our own (process) creds: [" << Process_credentials::own_process_credentials() << "].");
+
+  m_peer_process_creds = creds;
+
+  return true;
 } // Native_socket_stream::Impl::remote_peer_process_credentials()
 
 const std::string& Native_socket_stream::Impl::nickname() const

--- a/src/ipc/transport/sync_io/detail/native_socket_stream_impl.hpp
+++ b/src/ipc/transport/sync_io/detail/native_socket_stream_impl.hpp
@@ -401,6 +401,15 @@ public:
    */
   util::Process_credentials remote_peer_process_credentials(Error_code* err_code) const;
 
+  /**
+   * See Native_socket_stream counterpart.
+   *
+   * @param creds
+   *        See Native_socket_stream counterpart.
+   * @return See Native_socket_stream counterpart.
+   */
+  bool remote_peer_process_credentials(const util::Process_credentials& creds);
+
   // Connect-ops API.
 
   /**
@@ -1112,6 +1121,13 @@ private:
   template<Op OP>
   bool start_ops(util::sync_io::Event_wait_func&& ev_wait_func);
 
+  /**
+   * To be called if and only if #m_peer_socket is connected -- actually ideally at the moment it becomes connected
+   * originally (or construction in such state, whichever happens first) -- this saves the accurate values
+   * into #m_peer_process_creds by invoking the OS-get-sock-options call on #m_peer_socket.
+   */
+  void save_peer_process_creds();
+
   // Data.
 
   // General data (both-direction pipes, connects, general).
@@ -1338,6 +1354,12 @@ private:
    * just lives in peace, on death row, until it is safe to really close (in dtor).
    */
   boost::movelib::unique_ptr<asio_local_stream_socket::Peer_socket> m_peer_socket_hosed;
+
+  /**
+   * Cached value returned by remote_peer_process_credentials(); set at entry to PEER state and (subsequently,
+   * optionally) via remote_peer_process_credentials() mutator; unused in other state(s).
+   */
+  util::Process_credentials m_peer_process_creds;
 
   /**
    * Descriptor waitable by outside event loop async-waits -- storing the same `Native_handle` as (and thus being

--- a/src/ipc/transport/sync_io/native_socket_stream.cpp
+++ b/src/ipc/transport/sync_io/native_socket_stream.cpp
@@ -99,6 +99,11 @@ util::Process_credentials Native_socket_stream::remote_peer_process_credentials(
   return impl()->remote_peer_process_credentials(err_code);
 }
 
+bool Native_socket_stream::remote_peer_process_credentials(const util::Process_credentials& creds)
+{
+  return impl()->remote_peer_process_credentials(creds);
+}
+
 size_t Native_socket_stream::send_meta_blob_max_size() const
 {
   return impl()->send_meta_blob_max_size();

--- a/src/ipc/transport/sync_io/native_socket_stream.hpp
+++ b/src/ipc/transport/sync_io/native_socket_stream.hpp
@@ -581,27 +581,22 @@ public:
   // Misc API.
 
   /**
-   * OS-reported process credential (PID, etc.) info about the *other* connected peer's process, at the time
-   * that the OS first established (via local-socket-connect or local-socket-connected-pair-generate call) that
-   * opposing peer socket.  The value returned, assuming a non-error-emitting execution, shall always be the same for a
-   * given `*this`.
-   *
-   * Informally: To avoid (though, formally, not guarantee) error::Code::S_LOW_LVL_TRANSPORT_HOSED, it is best
-   * to call this immediately upon entry of `*this` to PEER state and/or before
-   * invoking any other APIs.
-   *
-   * If invoked outside of PEER state returns `Process_credentials()` immediately
-   * and otherwise does nothing.
-   *
-   * @return See above; or `Peer_credentials()` if invoked outside of PEER state or in case of error.
-   *         The 2 eventualities can be distinguished by checking `*err_code` truthiness.  Better yet
-   *         only call remote_peer_process_credentials() in PEER state, as it is otherwise conceptually meaningless.
+   * See transport::Native_socket_stream counterpart.
    *
    * @param err_code
-   *        See `flow::Error_code` docs for error reporting semantics.  #Error_code generated:
-   *        See #Async_io_obj counterpart doc header.
+   *        See transport::Native_socket_stream counterpart.
+   * @return See transport::Native_socket_stream counterpart.
    */
   util::Process_credentials remote_peer_process_credentials(Error_code* err_code = 0) const;
+
+  /**
+   * See transport::Native_socket_stream counterpart.
+   *
+   * @param creds
+   *        See transport::Native_socket_stream counterpart.
+   * @return See transport::Native_socket_stream counterpart.
+   */
+  bool remote_peer_process_credentials(const util::Process_credentials& creds);
 
 private:
   // Types.


### PR DESCRIPTION
Part of fix for: Flow-IPC/ipc#148

Code review: reviewed elsewhere by @wkorbe.